### PR TITLE
update `git clone` snippet in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # mocha-vs-ava-performance
-Setup to help identify performance problems for Ava
+Setup to help identify performance problems for AVA
 
 ### Motivation
-[Ava](https://github.com/sindresorhus/ava) is a test runner that is a promising alternative to [Mocha](https://github.com/mochajs/mocha). When trying to switch from Mocha to Ava, one thing that was pretty obvious is how slow it ran compared to Mocha, especially when comparing the 'watch' versions of both, even though Ava promised to be faster. The ideal result for Ava would be to give immediate feedback, just like Mocha does when in watch mode (at least on a restricted number of fast tests).
+[AVA](https://github.com/sindresorhus/ava) is a test runner that is a promising alternative to [Mocha](https://github.com/mochajs/mocha). When trying to switch from Mocha to AVA, one thing that was pretty obvious is how slow it ran compared to Mocha, especially when comparing the 'watch' versions of both, even though AVA promised to be faster. The ideal result for AVA would be to give immediate feedback, just like Mocha does when in watch mode (at least on a restricted number of fast tests).
 
-Here is a small setup with a few very simple tests, that can be used as a benchmark. Maybe Ava gets comparatively faster the more tests you have, but since when developing it often happens that I run only a few files to keep the feedback quick, I deem important the fact to run quickly even on small test bases. Node that the code is transpiled using Babel, so that takes a significant portion of the time.
+Here is a small setup with a few very simple tests, that can be used as a benchmark. Maybe AVA gets comparatively faster the more tests you have, but since when developing it often happens that I run only a few files to keep the feedback quick, I deem important the fact to run quickly even on small test bases. Node that the code is transpiled using Babel, so that takes a significant portion of the time.
 
 ### Setup
 
 ```
-git clone git@github.com:jfmengels/mocha-vs-ava-performance.git mocha-ava
+git clone https://github.com/jfmengels/mocha-vs-ava-performance.git mocha-ava
 cd mocha-ava
 npm install
 ```
@@ -24,7 +24,7 @@ __NOTE__: Most of these commands use Linux's `time` command for benchmark. If yo
 # Run tests once
 npm run test-mocha
 npm run test-ava
-npm run test-ava:no-cache # without the cache that Ava creates on its first run
+npm run test-ava:no-cache # without the cache that AVA creates on its first run
 
 # Watch code and run tests on change
 npm run test-mocha:watch
@@ -39,7 +39,7 @@ Times gotten from the time command, not the ones displayed by Mocha, since tests
 - Run once: 3.19s, 3.22s, 3.15s, 3.25s, 3.17s.
 - Watch: first run is probably the same as when run once, afterwards Mocha usually displays a time less than 10ms (there is no setup at every new run, making it very fast).
 
-#### Ava
+#### AVA
 
 - Run once: 5.14s, 5.97s, 4.85s, 5.09s, 5.23s.
 - Without cache: 8.35s, 8.34s, 8.31s, 7.94, 8.51s.
@@ -47,4 +47,4 @@ Times gotten from the time command, not the ones displayed by Mocha, since tests
 
 #### Note
 
-Oddly, and I have yet to discover the cause, when testing this repo by cloning it in a new folder, the tests ran considerably faster (<2s for Ava, <1s for Mocha) than they were in the original folder I wrote this all in. So the benchmark times were smaller, though Mocha was still much faster.
+Oddly, and I have yet to discover the cause, when testing this repo by cloning it in a new folder, the tests ran considerably faster (<2s for AVA, <1s for Mocha) than they were in the original folder I wrote this all in. So the benchmark times were smaller, though Mocha was still much faster.


### PR DESCRIPTION
Running the old clone script runs into the following error:

<pre>
❯ git clone git@github.com:jfmengels/mocha-vs-ava-performance.git mocha-ava
Cloning into 'mocha-ava'...
Warning: Permanently added the RSA host key for IP address <ADDRESS> to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
</pre>


Simply updating to `git clone https://github.com/jfmengels/mocha-vs-ava-performance.git mocha-ava` solves the problem.

I also corrected the spelling of `Ava` → `AVA`
